### PR TITLE
Add One-to-Many Relationship Between Category and Products

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/generations/loja_games_api/controller/CategoryController.java
+++ b/src/main/java/com/generations/loja_games_api/controller/CategoryController.java
@@ -1,0 +1,82 @@
+package com.generations.loja_games_api.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.generations.loja_games_api.model.Category;
+import com.generations.loja_games_api.repository.CategoryRepository;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/categories")
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+public class CategoryController {
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+
+  @GetMapping
+  public ResponseEntity<List<Category>> getAll() {
+    return ResponseEntity.ok(categoryRepository.findAll());
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<Category> getById(@PathVariable Long id) {
+    return categoryRepository.findById(id)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/name/{name}")
+  public ResponseEntity<List<Category>> getByName(@PathVariable String name) {
+    return ResponseEntity.ok(categoryRepository.findAllByNameContainingIgnoreCase(name));
+  }
+
+  @GetMapping("/description/{description}")
+  public ResponseEntity<List<Category>> getByDescription(@PathVariable String description) {
+    return ResponseEntity.ok(categoryRepository.findAllByDescriptionContainingIgnoreCase(description));
+  }
+
+  @PostMapping
+  public ResponseEntity<Category> create(@Valid @RequestBody Category category) {
+    Category savedCategory = categoryRepository.save(category);
+    return ResponseEntity.status(HttpStatus.CREATED).body(savedCategory);
+  }
+
+  @PutMapping
+  public ResponseEntity<Category> update(@Valid @RequestBody Category category) {
+    if (category.getId() == null)
+      return ResponseEntity.notFound().build();
+
+    return categoryRepository.findById(category.getId())
+        .map(existingCategory -> ResponseEntity.ok(categoryRepository.save(category)))
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @DeleteMapping("/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void delete(@PathVariable Long id) {
+
+    if (!categoryRepository.existsById(id)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Categoria não encontrada");
+    }
+
+    categoryRepository.deleteById(id);
+  }
+
+}

--- a/src/main/java/com/generations/loja_games_api/controller/CategoryController.java
+++ b/src/main/java/com/generations/loja_games_api/controller/CategoryController.java
@@ -61,7 +61,7 @@ public class CategoryController {
   @PutMapping
   public ResponseEntity<Category> update(@Valid @RequestBody Category category) {
     if (category.getId() == null)
-      return ResponseEntity.notFound().build();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
 
     return categoryRepository.findById(category.getId())
         .map(existingCategory -> ResponseEntity.ok(categoryRepository.save(category)))

--- a/src/main/java/com/generations/loja_games_api/controller/ProductController.java
+++ b/src/main/java/com/generations/loja_games_api/controller/ProductController.java
@@ -1,0 +1,94 @@
+package com.generations.loja_games_api.controller;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.generations.loja_games_api.model.Product;
+import com.generations.loja_games_api.repository.ProductRepository;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/products")
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+public class ProductController {
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @GetMapping
+  public ResponseEntity<List<Product>> getAll() {
+    return ResponseEntity.ok(productRepository.findAll());
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<Product> getById(@PathVariable Long id) {
+    return productRepository.findById(id)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/name/{name}")
+  public ResponseEntity<List<Product>> getByName(@PathVariable String name) {
+    return ResponseEntity.ok(productRepository.findAllByNameContainingIgnoreCase(name));
+  }
+
+  @GetMapping("/description/{description}")
+  public ResponseEntity<List<Product>> getByDescription(@PathVariable String description) {
+    return ResponseEntity.ok(productRepository.findAllByDescriptionContainingIgnoreCase(description));
+  }
+
+  @GetMapping("/price/{price}")
+  public ResponseEntity<List<Product>> getByPrice(@PathVariable BigDecimal price) {
+    return ResponseEntity.ok(productRepository.findAllByPrice(price));
+  }
+
+  @PostMapping
+  public ResponseEntity<Product> create(@Valid @RequestBody Product product) {
+    Product savedProduct = productRepository.save(product);
+    return ResponseEntity.status(HttpStatus.CREATED).body(savedProduct);
+  }
+
+  @PutMapping
+  public ResponseEntity<Product> update(@Valid @RequestBody Product product) {
+
+    if (product.getId() == null)
+      return ResponseEntity.notFound().build();
+
+    return productRepository.findById(product.getId())
+        .map(response -> {
+          if (!productRepository.existsById(product.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Produto não encontrado");
+          }
+          return ResponseEntity.ok(productRepository.save(product));
+        })
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @DeleteMapping("/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void delete(@PathVariable Long id) {
+
+    if (!productRepository.existsById(id)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Produto não encontrado");
+    }
+
+    productRepository.deleteById(id);
+  }
+
+}

--- a/src/main/java/com/generations/loja_games_api/controller/ProductController.java
+++ b/src/main/java/com/generations/loja_games_api/controller/ProductController.java
@@ -71,12 +71,7 @@ public class ProductController {
       return ResponseEntity.notFound().build();
 
     return productRepository.findById(product.getId())
-        .map(response -> {
-          if (!productRepository.existsById(product.getId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Produto não encontrado");
-          }
-          return ResponseEntity.ok(productRepository.save(product));
-        })
+        .map(existingProduct -> ResponseEntity.ok(productRepository.save(product)))
         .orElse(ResponseEntity.notFound().build());
   }
 

--- a/src/main/java/com/generations/loja_games_api/model/Category.java
+++ b/src/main/java/com/generations/loja_games_api/model/Category.java
@@ -1,0 +1,32 @@
+package com.generations.loja_games_api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "tb_categories")
+public class Category {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 100)
+  @NotBlank(message = "O nome da categoria é obrigatório")
+  @Size(min = 5, max = 100, message = "O atributo nome deve ter no mínimo 5 e no máximo 100 caracteres!")
+  private String name;
+
+  @Column(length = 1000)
+  @NotBlank(message = "A descrição da categoria é obrigatória")
+  @Size(min = 10, max = 1000, message = "O atributo descrição deve ter no mínimo 10 e no máximo 1000 caracteres!")
+  private String description;
+
+}

--- a/src/main/java/com/generations/loja_games_api/model/Category.java
+++ b/src/main/java/com/generations/loja_games_api/model/Category.java
@@ -1,10 +1,17 @@
 package com.generations.loja_games_api.model;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -28,5 +35,9 @@ public class Category {
   @NotBlank(message = "A descrição da categoria é obrigatória")
   @Size(min = 10, max = 1000, message = "O atributo descrição deve ter no mínimo 10 e no máximo 1000 caracteres!")
   private String description;
+
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "category", cascade = CascadeType.REMOVE)
+  @JsonIgnoreProperties("category")
+  private List<Product> products;
 
 }

--- a/src/main/java/com/generations/loja_games_api/model/Product.java
+++ b/src/main/java/com/generations/loja_games_api/model/Product.java
@@ -5,11 +5,14 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
@@ -52,4 +55,8 @@ public class Product {
 
   @UpdateTimestamp
   private LocalDateTime date;
+
+  @ManyToOne
+  @JsonIgnoreProperties("products")
+  private Category category;
 }

--- a/src/main/java/com/generations/loja_games_api/model/Product.java
+++ b/src/main/java/com/generations/loja_games_api/model/Product.java
@@ -1,0 +1,55 @@
+package com.generations.loja_games_api.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "tb_products")
+public class Product {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 100)
+  @NotBlank(message = "O nome do produto é obrigatório")
+  @Size(min = 5, max = 100, message = "O atributo nome deve ter no mínimo 5 e no máximo 100 caracteres!")
+  private String name;
+
+  @Column(length = 1000)
+  @NotBlank(message = "A descrição do produto é obrigatória")
+  @Size(min = 10, max = 1000, message = "O atributo descrição deve ter no mínimo 10 e no máximo 1000 caracteres!")
+  private String description;
+
+  @Column(precision = 10, scale = 2)
+  @NotNull(message = "O preço do produto é obrigatório")
+  @DecimalMin(value = "0.00", inclusive = false, message = "O preço deve ser maior que zero")
+  @Digits(integer = 8, fraction = 2, message = "O preço deve ter no máximo 8 dígitos inteiros e 2 decimais")
+  private BigDecimal price;
+
+  @Column(length = 5000)
+  @NotBlank(message = "A imagem do produto é obrigatória")
+  @Size(min = 10, max = 5000, message = "O atributo imagem deve ter no mínimo 10 e no máximo 5000 caracteres!")
+  @Pattern(regexp = "^(https?|ftp)://.*$", message = "A URL da imagem deve ser válida")
+  private String image;
+
+  @UpdateTimestamp
+  private LocalDateTime date;
+}

--- a/src/main/java/com/generations/loja_games_api/repository/CategoryRepository.java
+++ b/src/main/java/com/generations/loja_games_api/repository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package com.generations.loja_games_api.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.generations.loja_games_api.model.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+  List<Category> findAllByNameContainingIgnoreCase(String name);
+
+  List<Category> findAllByDescriptionContainingIgnoreCase(String description);
+
+}

--- a/src/main/java/com/generations/loja_games_api/repository/ProductRepository.java
+++ b/src/main/java/com/generations/loja_games_api/repository/ProductRepository.java
@@ -1,0 +1,18 @@
+package com.generations.loja_games_api.repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.generations.loja_games_api.model.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+  List<Product> findAllByNameContainingIgnoreCase(String name);
+
+  List<Product> findAllByDescriptionContainingIgnoreCase(String description);
+
+  List<Product> findAllByPrice(BigDecimal price);
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=loja_games_api
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database=mysql
+spring.datasource.url=jdbc:mysql://localhost/db_lojagames?createDatabaseIfNotExist=true&serverTimezone=America/Sao_Paulo&useSSl=false
+spring.datasource.username=root
+spring.datasource.password=NovaSenhaSegura123!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+ 
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQLDialect
+ 
+spring.jpa.properties.jakarta.persistence.sharedCache.mode=ENABLE_SELECTIVE
+ 
+spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
+spring.jackson.time-zone=Brazil/East


### PR DESCRIPTION
This pull request introduces a one-to-many relationship between the Category and Products entities. Each product is now associated with a specific category through a foreign key. 

### Changes made:
- Created a foreign key in the Products table referencing the Category table.
- Updated models/schemas to reflect the relationship.
- Added seed data to test the association (if applicable).
- Ensured referential integrity between the tables.

This relationship allows each category to have multiple products, improving data organization and query capabilities.

Please review and let me know if any adjustments are needed.
